### PR TITLE
Fix submission subs

### DIFF
--- a/app/client/templates/admin/submissionReview.js
+++ b/app/client/templates/admin/submissionReview.js
@@ -27,9 +27,11 @@ Template.submissionReview.helpers({
 Template.submissionReview.onCreated(function() {
   var _this = this;
 
-  Meteor.subscribe('ratings', Meteor.userId());
-  Meteor.subscribe('allRatings');
-  Meteor.subscribe('committeeUsers');
+  _this.autorun(function () {
+    Meteor.subscribe('ratings', Meteor.userId());
+    Meteor.subscribe('allRatings');
+    Meteor.subscribe('committeeUsers');
+  });
 
 });
 

--- a/app/client/templates/admin/submissionReview.js
+++ b/app/client/templates/admin/submissionReview.js
@@ -9,8 +9,10 @@ Template.submissionReview.helpers({
   },
 
   ratingByUser: function(userId) {
+    var application = Applications.findOne();
     var rating = Ratings.findOne({
       userId: userId,
+      applicationId: application._id
     }, {
       'rating': true,
     });
@@ -29,9 +31,14 @@ Template.submissionReview.onCreated(function() {
 
   _this.autorun(function () {
     Meteor.subscribe('ratings', Meteor.userId());
-    Meteor.subscribe('allRatings');
     Meteor.subscribe('committeeUsers');
   });
+
+  if( Roles.userIsInRole( Meteor.userId(), ['admin'] ) ) {
+    _this.autorun(function () {
+      Meteor.subscribe('allRatings');
+    });
+  }
 
 });
 


### PR DESCRIPTION
I moved this back inside the autorun because guide:

_Stopping Subscriptions_

_The subscription handle also has another important property, the .stop() method. When you are subscribing, it is very important to ensure that you always call .stop() on the subscription when you are done with it. This ensures that the documents sent by the subscription are cleared from your local Minimongo cache and the server stops doing the work required to service your subscription. If you forget to call stop, you’ll consume unnecessary resources both on the client and the server._

_However, if you call Meteor.subscribe() conditionally inside a reactive context (such as an autorun, or getMeteorData in React) or via this.subscribe() in a Blaze component, then Meteor’s reactive system will automatically call this.stop() for you at the appropriate time._
http://guide.meteor.com/data-loading.html#stopping-subscriptions

Also applied some role check security.
Fixed `ratingByUser()`.
